### PR TITLE
Miscellaneous fixes

### DIFF
--- a/which_fonts_support.py
+++ b/which_fonts_support.py
@@ -129,7 +129,7 @@ def available_font_for_codepoint(codepoint):
             'run fc-list failed, please check your environment\n'
         )
 
-    descriptions = result.stdout.decode('utf-8').split('\n')
+    descriptions = result.stdout.decode('utf-8', 'replace').split('\n')
 
     last_font_fullname = last_font_family = ''
     for line in descriptions:

--- a/which_fonts_support.py
+++ b/which_fonts_support.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import sys, re, subprocess, binascii, collections, argparse, tempfile, webbrowser
+import sys, re, os, subprocess, binascii, collections, argparse, tempfile, time, webbrowser
 
 import wcwidth
 
@@ -216,6 +216,8 @@ def __main():
         f.write(html.encode('utf-8'))
         f.close()
         webbrowser.open(f.name)
+        time.sleep(5)  # Give the browser time to open the page
+        os.remove(f.name)
 
 if __name__ == '__main__':
     __main()

--- a/which_fonts_support.py
+++ b/which_fonts_support.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import sys, re, subprocess, binascii, collections, argparse, tempfile
+import sys, re, subprocess, binascii, collections, argparse, tempfile, webbrowser
 
 import wcwidth
 
@@ -214,7 +214,8 @@ def __main():
         )
         f = tempfile.NamedTemporaryFile(suffix='.html', delete=False)
         f.write(html.encode('utf-8'))
-        subprocess.Popen(['open', f.name])
+        f.close()
+        webbrowser.open(f.name)
 
 if __name__ == '__main__':
     __main()


### PR DESCRIPTION
The illegal UTF-8 sequences cropped up on my machine due to a font that uses legacy encoding in one of its fields (the foundry name, which has a Windows Codepage 1252 ® in it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/7sdream/which_fonts_support/2)
<!-- Reviewable:end -->
